### PR TITLE
Refactorings

### DIFF
--- a/lib/predicator/errors/instruction_error.ex
+++ b/lib/predicator/errors/instruction_error.ex
@@ -29,7 +29,7 @@ defmodule Predicator.InstructionError do
       instructions: machine.instructions,
       predicate: predicate,
       stack: machine.stack,
-      instruction_pointer: machine.ip,
+      instruction_pointer: machine.instruction_pointer,
       opts: machine.opts
       }
     }

--- a/lib/predicator/errors/instruction_not_complete_error.ex
+++ b/lib/predicator/errors/instruction_not_complete_error.ex
@@ -26,7 +26,7 @@ defmodule Predicator.InstructionNotCompleteError do
     {:error, %__MODULE__{
       stack: machine.stack,
       instructions: machine.instructions,
-      instruction_pointer: machine.ip,
+      instruction_pointer: machine.instruction_pointer,
       opts: machine.opts
       }
     }

--- a/lib/predicator/errors/value_error.ex
+++ b/lib/predicator/errors/value_error.ex
@@ -26,7 +26,7 @@ defmodule Predicator.ValueError do
     {:error, %__MODULE__{
         stack: machine.stack,
         instructions: machine.instructions,
-        instruction_pointer: machine.ip,
+        instruction_pointer: machine.instruction_pointer,
         opts: machine.opts
       }
     }

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -2,17 +2,13 @@ defmodule Predicator.Evaluator do
   @moduledoc "Evaluator Module"
   alias Predicator.{
     Machine,
-    InstructionError,
-    InstructionNotCompleteError,
-    ValueError,
   }
 
-  @doc "Error types returned from Predicator.Evaluator"
+  @typedoc "Error types returned from Predicator.Evaluator"
   @type error_t :: {:error,
     InstructionError.t()
     | ValueError.t()
     | InstructionNotCompleteError.t() }
-
 
   @doc ~S"""
   Execute will evaluate a predicator instruction set.
@@ -22,239 +18,34 @@ defmodule Predicator.Evaluator do
 
   ### Examples:
 
-      iex> Predicator.Evaluator.execute([["lit", true]])
-      true
+  iex> Predicator.Evaluator.execute([["lit", true]])
+  true
 
-      iex> Predicator.Evaluator.execute([["lit", 2], ["lit", 3], ["compare", "LT"]])
-      true
+  iex> Predicator.Evaluator.execute([["lit", 2], ["lit", 3], ["comparator", "LT"]])
+  true
 
-      iex> Predicator.Evaluator.execute([["load", "age"], ["lit", 18], ["compare", "GT"]], %{age: 19})
-      true
+  iex> Predicator.Evaluator.execute([["load", "age"], ["lit", 18], ["comparator", "GT"]], %{age: 19})
+  true
 
-      iex> Predicator.Evaluator.execute([["load", "name"], ["lit", "jrichocean"], ["compare", "EQ"]], %{age: 19})
-      {:error, %Predicator.ValueError{error: "Non valid load value to evaluate", instruction_pointer: 0, instructions: [["load", "name"], ["lit", "jrichocean"], ["compare", "EQ"]], stack: [], opts: [map_type: :atom, nil_values: ["", nil]]}}
+  iex> Predicator.Evaluator.execute([["load", "name"], ["lit", "jrichocean"], ["comparator", "EQ"]], %{age: 19})
+  {:error, %Predicator.ValueError{error: "Non valid load value to evaluate", instruction_pointer: 0, instructions: [["load", "name"], ["lit", "jrichocean"], ["comparator", "EQ"]], stack: [], opts: [map_type: :atom, nil_values: ["", nil]]}}
 
-      iex> Predicator.Evaluator.execute([["load", "age"], ["lit", 18], ["compare", "GT"]], %{"age" => 19}, [map_type: :string])
-      true
+  iex> Predicator.Evaluator.execute([["load", "age"], ["lit", 18], ["comparator", "GT"]], %{"age" => 19}, [map_type: :string])
+  true
 
   """
   @spec execute(list(), struct()|map()) :: boolean() | error_t
-  def execute(inst, context_struct \\ %{}, opts \\ [map_type: :atom, nil_values: ["", nil]]) do
-    machine = %Machine{instructions: inst, context_struct: context_struct, opts: opts}
-    _execute(_next_ip(machine), machine)
+  def execute(inst, context \\ %{}, opts \\ [map_type: :string, nil_values: ["", nil]]) do
+    inst
+    |> Machine.new(context, opts)
+    |> run
   end
 
-  def _execute(nil, m = %Machine{stack: [first|_]})
-    when not is_boolean(first), do: InstructionNotCompleteError.inst_not_complete_error(m)
-  def _execute(nil, machine), do: hd(machine.stack)
-
-  def _execute(["array"|[val|_]], machine=%Machine{}) do
-    machine = %Machine{ machine | stack: [val|machine.stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["lit"|[val|_]], machine=%Machine{}) do
-    machine = %Machine{ machine | stack: [val|machine.stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["not"|_], machine=%Machine{stack: [val|_rest_of_stack]}) do
-    machine = %Machine{ machine | stack: [!val|machine.stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-
-  # Conversion Predicates
-  def _execute(["to_bool"|_], machine=%Machine{stack: [val|rest_of_stack]}) when val in ["true", "false"] do
-    machine = %Machine{machine| stack: [String.to_existing_atom(val)|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["to_bool"|_], machine=%Machine{stack: [val|rest_of_stack]}) when is_boolean(val) do
-    machine = %Machine{machine| stack: [val|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["to_bool"|_], machine=%Machine{}), do: ValueError.value_error(machine)
-
-  def _execute(["to_str"|_], machine=%Machine{stack: [val|rest_of_stack]}) when is_nil(val) do
-    machine = %Machine{machine| stack: ["nil"|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["to_str"|_], machine=%Machine{stack: [val|rest_of_stack]}) do
-    machine = %Machine{machine| stack: [to_string(val)|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["to_int"|_], machine=%Machine{stack: [val|rest_of_stack]}) when is_binary(val) do
-    case Integer.parse(val) do
-      {integer, _} ->
-        machine =
-          %Machine{machine| stack: [integer|rest_of_stack], ip: machine.ip + 1 }
-        _execute(_next_ip(machine), machine)
-      :error -> ValueError.value_error(machine)
+  defp run(%Machine{stack: [head | _]}) when is_boolean(head), do: head
+  defp run(%Machine{} = machine) do
+    case Machine.step(machine) do
+      %Machine{} = machine -> run(machine)
+      {:error, _reason} = err -> err
     end
   end
-  def _execute(["to_int"|_], machine=%Machine{stack: [val|rest_of_stack]}) when is_integer(val) do
-    m = %Machine{machine| stack: [val|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(m), m)
-  end
-
-
-  def _execute(inst=["to_date"|_], machine=%Machine{}),
-    do: Predicator.Evaluator.Date._execute(inst, machine)
-
-  def _execute(inst=["date_ago"|_], machine=%Machine{}),
-    do: Predicator.Evaluator.Date._execute(inst, machine)
-
-  def _execute(inst=["date_from_now"|_], machine=%Machine{}),
-    do: Predicator.Evaluator.Date._execute(inst, machine)
-
-
-  def _execute(["blank"], machine=%Machine{stack: [val|rest_of_stack], opts: opts}) do
-    machine = case Enum.member?(opts[:nil_values], val) do
-      true ->
-        %Machine{machine| stack: [true|rest_of_stack], ip: machine.ip + 1 }
-      false ->
-        %Machine{machine| stack: [false|rest_of_stack], ip: machine.ip + 1 }
-    end
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["present"], machine=%Machine{stack: [val|rest_of_stack], opts: opts}) do
-    machine = case Enum.member?(opts[:nil_values], val) do
-      true ->
-        %Machine{machine| stack: [false|rest_of_stack], ip: machine.ip + 1 }
-      false ->
-        %Machine{machine| stack: [true|rest_of_stack], ip: machine.ip + 1 }
-    end
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["compare"|["EQ"|_]], machine=%Machine{stack: [left|[right|rest_of_stack]]}) do
-    val = left == right
-    machine = %Machine{ machine | stack: [val|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["compare"|["EQ"|_]], machine) do
-    machine = %Machine{ machine| stack: [false| machine.stack] }
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["compare"|["IN"|_]], machine=%Machine{stack: [left|[right|rest_of_stack]]}) do
-    val = Enum.member?(left, right)
-    machine = %Machine{ machine | stack: [val|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["compare"|["IN"|_]], machine) do
-    machine = %Machine{ machine| stack: [false| machine.stack] }
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["compare"|["NOTIN"|_]], machine=%Machine{stack: [left|[right|rest_of_stack]]}) do
-    val = !Enum.member?(left, right)
-    machine = %Machine{ machine | stack: [val|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["compare"|["NOTIN"|_]], machine) do
-      mach =
-        %Machine{ machine| stack: [false| machine.stack] }
-
-      _execute(_next_ip(mach), mach)
-  end
-
-  def _execute(["compare"|["GT"|_]], machine=%Machine{stack: [second|[first|_rest_of_stack]]}) do
-    val = first > second
-    machine = %Machine{ machine | stack: [val|machine.stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["compare"|["GT"|_]], machine) do
-    machine = %Machine{ machine| stack: [false| machine.stack] }
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["compare"|["LT"|_]], machine=%Machine{stack: [second|[first|_rest_of_stack]]}) do
-    val = first < second
-    machine = %Machine{ machine | stack: [val|machine.stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["compare"|["LT"|_]], machine) do
-    machine = %Machine{ machine| stack: [false| machine.stack] }
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(
-    ["compare"|["BETWEEN"|_]], m=%Machine{stack: [max=%DateTime{}|[min=%DateTime{}|[val=%DateTime{}|rest_of_stack]]]}
-  ) do
-    is_between_eval =
-      with :gt <- DateTime.compare(max, val),
-           :lt <- DateTime.compare(min, val)
-      do
-        true
-      else
-        _ -> false
-      end
-    machine = %Machine{m| stack: [is_between_eval|rest_of_stack], ip: m.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-  def _execute(["compare"|["BETWEEN"|_]], machine=%Machine{stack: [max|[min|[val|rest_of_stack]]]}) do
-    res = Enum.member?(min..max, val)
-    machine = %Machine{ machine| stack: [res|rest_of_stack], ip: machine.ip + 1 }
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["compare"|["STARTSWITH"|_]], m = %Machine{stack: [match|[stack_val|rest_of_stack]]}) do
-    val = String.starts_with?(stack_val, match)
-    machine = %Machine{m| stack: [val|rest_of_stack], ip: m.ip + 1}
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["compare"|["ENDSWITH"|_]], m = %Machine{stack: [end_match|[stack_val|rest_of_stack]]}) do
-    val = String.ends_with?(stack_val, end_match)
-    machine = %Machine{m| stack: [val|rest_of_stack], ip: m.ip + 1}
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["load"|[val|_]], machine=%Machine{opts: [map_type: :string]}) do
-    case Map.get(machine.context_struct, val, :nokey) do
-      :nokey -> ValueError.value_error(machine)
-      user_key ->
-        machine = %Machine{ machine | stack: [user_key|machine.stack], ip: machine.ip + 1 }
-        _execute(_next_ip(machine), machine)
-    end
-  end
-  def _execute(["load"|[val|_]], machine=%Machine{}) do
-    case Map.get(machine.context_struct, String.to_existing_atom(val), :nokey) do
-      :nokey -> ValueError.value_error(machine)
-      user_key ->
-        machine = %Machine{ machine | stack: [user_key|machine.stack], ip: machine.ip + 1 }
-        _execute(_next_ip(machine), machine)
-    end
-  end
-
-  def _execute(["jfalse"|[offset|_]], machine=%Machine{}) do
-    machine =
-    case hd(machine.stack) do
-      false -> %Machine{machine| ip: machine.ip + offset}
-      _ -> %Machine{machine| stack: tl(machine.stack), ip: machine.ip + 1}
-    end
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute(["jtrue"|[offset|_]], machine=%Machine{}) do
-    machine =
-    case hd(machine.stack) do
-      true -> %Machine{machine| ip: machine.ip + offset}
-      _ -> %Machine{machine| stack: tl(machine.stack), ip: machine.ip + 1}
-    end
-    _execute(_next_ip(machine), machine)
-  end
-
-  def _execute([non_recognized_predicate|_], machine=%Machine{}),
-    do: InstructionError.instruction_error(machine, non_recognized_predicate)
-
-  def _next_ip(machine=%Machine{}) do
-    case machine.ip < Enum.count(machine.instructions) do
-      true -> Enum.at(machine.instructions, machine.ip)
-      _ -> nil
-    end
-  end
-
 end

--- a/lib/predicator/evaluator/date.ex
+++ b/lib/predicator/evaluator/date.ex
@@ -5,41 +5,27 @@ defmodule Predicator.Evaluator.Date do
     DateConversionError
   }
 
-
-  def _execute(["to_date"|_], m=%Machine{stack: [date|rest_of_stack]}) do
-    mach =
-      %Machine{m| stack: [_convert_date(date)|rest_of_stack], ip: m.ip + 1 }
-
-    mach
-    |> Predicator.Evaluator._next_ip()
-    |> Predicator.Evaluator._execute(mach)
+  def _execute(["to_date"|_], machine=%Machine{stack: [date|_rest_of_stack]}) do
+    Machine.put_instruction(machine, _convert_date(date))
   end
 
   # [["load", "created_at"], ["to_date"], ["lit", 259200], ["date_ago"], ["compare", "LT"]]
-  def _execute(["date_ago"|_], m=%Machine{stack: [date_in_seconds|rest_of_stack]}) do
+  def _execute(["date_ago"|_], machine=%Machine{stack: [date_in_seconds|_rest_of_stack]}) do
     with {:ok, dt_from_stack} <- DateTime.from_unix(date_in_seconds),
          diff_in_seconds <- DateTime.diff(DateTime.utc_now, dt_from_stack),
          {:ok, datetime} <- DateTime.from_unix(diff_in_seconds)
     do
-      mach =
-        %Machine{m|stack: [datetime|rest_of_stack], ip: m.ip + 1 }
-
-      Predicator.Evaluator._next_ip(mach)
-      |> Predicator.Evaluator._execute(mach)
+      Machine.put_instruction(machine, datetime)
     end
   end
 
-  def _execute(["date_from_now"|_], m=%Machine{stack: [seconds_from_now|rest_of_stack]}) do
+  def _execute(["date_from_now"|_], machine=%Machine{stack: [seconds_from_now|_rest_of_stack]}) do
     date_from_now =
       DateTime.utc_now
       |> DateTime.to_unix
       |> add(seconds_from_now)
 
-    mach =
-      %Machine{m|stack: [date_from_now|rest_of_stack], ip: m.ip + 1 }
-
-    Predicator.Evaluator._next_ip(mach)
-    |> Predicator.Evaluator._execute(mach)
+    Machine.put_instruction(machine, date_from_now)
   end
 
 
@@ -62,5 +48,4 @@ defmodule Predicator.Evaluator.Date do
   end
 
   defp add(now, seconds_from_now), do: now + seconds_from_now
-
 end

--- a/lib/predicator/machine.ex
+++ b/lib/predicator/machine.ex
@@ -3,21 +3,240 @@ defmodule Predicator.Machine do
   A Machine Struct is comprised of the instructions set, the current stack, the instruction pointer and the context struct.
 
     iex>%Predicator.Machine{}
-    %Predicator.Machine{instructions: [], stack: [], ip: 0, context_struct: nil, opts: []}
+    %Predicator.Machine{instructions: [], stack: [], instruction_pointer: 0, context: nil, opts: []}
   """
+  alias Predicator.{
+    ValueError,
+    InstructionError,
+    InstructionNotCompleteError
+  }
+
   defstruct [
     instructions: [],
     stack: [],
-    ip: 0,
-    context_struct: nil,
+    instruction_pointer: 0,
+    context: %{},
     opts: []
   ]
 
   @type t :: %__MODULE__{
     instructions: [] | [...],
     stack: [] | [...],
-    ip: non_neg_integer(),
-    context_struct: struct() | map(),
+    instruction_pointer: non_neg_integer(),
+    context: struct() | map(),
     opts: [{atom, atom}, ...] | [{atom, [...]}, ...]
   }
+
+  def new(instructions, context, opts) do
+    %__MODULE__{instructions: instructions, context: context, opts: opts}
+  end
+
+  def step(%__MODULE__{} = machine) do
+    next_instruction = next_instruction(machine)
+    accept_instruction(machine, next_instruction)
+  end
+
+  def put_instruction(%__MODULE__{} = machine, instruction, opts \\ []) do
+    pointer =
+      if Keyword.get(opts, :increment, true) do
+        machine.instruction_pointer + 1
+      else
+        machine.instruction_pointer
+      end
+
+    %__MODULE__{ machine | stack: [instruction | machine.stack], instruction_pointer: pointer }
+  end
+
+  def next_instruction(%__MODULE__{} = machine) do
+    case machine.instruction_pointer < Enum.count(machine.instructions) do
+      true -> Enum.at(machine.instructions, machine.instruction_pointer)
+      _ -> nil
+    end
+  end
+
+  def increment_pointer(%__MODULE__{} = machine, amount) do
+    %__MODULE__{machine | instruction_pointer: machine.instruction_pointer + amount}
+  end
+
+  def pop_instruction(%__MODULE__{} = machine) do
+    %__MODULE__{ machine | stack: tl(machine.stack), instruction_pointer: machine.instruction_pointer + 1 }
+  end
+
+  def load!(%__MODULE__{} = machine, key) when is_atom(key) do
+    load!(machine, Atom.to_string(key))
+  end
+
+  def load!(%__MODULE__{context: context} = machine, key) when is_binary(key) do
+    if has_variable?(machine, key) do
+      Map.get(context, key)
+    else
+      ValueError.value_error(machine)
+    end
+  end
+
+  def has_variable?(%__MODULE__{context: context}, key) when is_binary(key) do
+    Map.has_key?(context, key)
+  end
+
+  def has_variable?(%__MODULE__{context: context}, key) when is_atom(key) do
+    Map.has_key?(context, Atom.to_string(key))
+  end
+
+  def accept_instruction(m = %__MODULE__{stack: [first|_]}, nil)
+  when not is_boolean(first), do: InstructionNotCompleteError.inst_not_complete_error(m)
+  def accept_instruction(machine, nil), do: hd(machine.stack)
+
+  def accept_instruction(machine = %__MODULE__{}, ["array"|[val|_]]) do
+    put_instruction(machine, val)
+  end
+
+  def accept_instruction(machine = %__MODULE__{}, ["lit"|[val|_]]) do
+    put_instruction(machine, val)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack]}, ["not"|_]) do
+    put_instruction(machine, val)
+  end
+
+  # Conversion Predicates
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack]}, ["to_bool"|_]) when val in ["true", "false"] do
+    put_instruction(machine, val)
+  end
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack]}, ["to_bool"|_]) when is_boolean(val) do
+    put_instruction(machine, val)
+  end
+  def accept_instruction(machine = %__MODULE__{}, ["to_bool"|_]), do: ValueError.value_error(machine)
+
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack]}, ["to_str"|_]) when is_nil(val) do
+    put_instruction(machine, val)
+  end
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack]}, ["to_str"|_]) do
+    put_instruction(machine, val)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack]}, ["to_int"|_]) when is_binary(val) do
+    case Integer.parse(val) do
+      {integer, _} ->
+        put_instruction(machine, integer)
+
+      :error ->
+        ValueError.value_error(machine)
+    end
+  end
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack]}, ["to_int"|_]) when is_integer(val) do
+    put_instruction(machine, val)
+  end
+
+  def accept_instruction(machine = %__MODULE__{}, inst=["to_date"|_]),
+  do: Predicator.Evaluator.Date._execute(inst, machine)
+
+  def accept_instruction(machine = %__MODULE__{}, inst=["date_ago"|_]),
+  do: Predicator.Evaluator.Date._execute(inst, machine)
+
+  def accept_instruction(machine = %__MODULE__{}, inst=["date_from_now"|_]),
+  do: Predicator.Evaluator.Date._execute(inst, machine)
+
+
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack], opts: opts}, ["blank"]) do
+    val = Enum.member?(opts[:nil_values], val)
+    put_instruction(machine, val)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [val|_rest_of_stack], opts: opts}, ["present"]) do
+    val = !(Enum.member?(opts[:nil_values], val))
+    put_instruction(machine, val)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [left|[right|_rest_of_stack]]}, ["comparator"|["EQ"|_]]) do
+    put_instruction(machine, left == right)
+  end
+  def accept_instruction(machine, ["comparator"|["EQ"|_]]) do
+    put_instruction(machine, false, increment: false)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [left|[right|_rest_of_stack]]}, ["comparator"|["IN"|_]]) do
+    val = Enum.member?(left, right)
+    put_instruction(machine, val)
+  end
+  def accept_instruction(machine, ["comparator"|["IN"|_]]) do
+    put_instruction(machine, false, increment: false)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [left|[right|_rest_of_stack]]}, ["comparator"|["NOTIN"|_]]) do
+    val = !Enum.member?(left, right)
+    put_instruction(machine, val)
+  end
+  def accept_instruction(machine, ["comparator"|["NOTIN"|_]]) do
+    put_instruction(machine, false, increment: false)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [second|[first|_rest_of_stack]]}, ["comparator"|["GT"|_]]) do
+    put_instruction(machine, first > second)
+  end
+  def accept_instruction(machine, ["comparator"|["GT"|_]]) do
+    put_instruction(machine, false, increment: false)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [second|[first|_rest_of_stack]]}, ["comparator"|["LT"|_]]) do
+    put_instruction(machine, first < second)
+  end
+  def accept_instruction(machine, ["comparator"|["LT"|_]]) do
+    put_instruction(machine, false, increment: false)
+  end
+
+  def accept_instruction(
+    machine = %__MODULE__{stack: [max=%DateTime{}|[min=%DateTime{}|[val=%DateTime{}|_rest_of_stack]]]}, ["comparator"|["BETWEEN"|_]]
+  ) do
+    is_between =
+      with :gt <- DateTime.compare(max, val),
+           :lt <- DateTime.compare(min, val)
+      do
+        true
+      else
+        _ -> false
+      end
+
+    put_instruction(machine, is_between)
+  end
+  def accept_instruction(machine = %__MODULE__{stack: [max|[min|[val|_rest_of_stack]]]}, ["comparator"|["BETWEEN"|_]]) do
+    put_instruction(machine, val in min..max)
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [match|[stack_val|_rest_of_stack]]}, ["comparator"|["STARTSWITH"|_]]) do
+    put_instruction(machine, String.starts_with?(stack_val, match))
+  end
+
+  def accept_instruction(machine = %__MODULE__{stack: [end_match|[stack_val|_rest_of_stack]]}, ["comparator"|["ENDSWITH"|_]]) do
+    put_instruction(machine, String.ends_with?(stack_val, end_match))
+  end
+
+  def accept_instruction(machine = %__MODULE__{}, ["load"|[val|_]]) do
+    if has_variable?(machine, val) do
+      user_key = load!(machine, val)
+      put_instruction(machine, user_key)
+    else
+      ValueError.value_error(machine)
+    end
+  end
+
+  def accept_instruction(machine = %__MODULE__{}, ["jfalse"|[offset|_]]) do
+    case hd(machine.stack) do
+      false ->
+        increment_pointer(machine, offset)
+      _ ->
+        pop_instruction(machine)
+    end
+  end
+
+  def accept_instruction(machine = %__MODULE__{}, ["jtrue"|[offset|_]]) do
+    case hd(machine.stack) do
+      true ->
+        increment_pointer(machine, offset)
+      _ ->
+        put_instruction(machine, tl(machine.stack))
+    end
+  end
+
+  def accept_instruction(machine = %__MODULE__{}, [non_recognized_predicate|_]),
+  do: InstructionError.instruction_error(machine, non_recognized_predicate)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Predicator.Mixfile do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       package: package(),
+      aliases: aliases(),
       description: description(),
       deps: deps()
     ]
@@ -24,6 +25,10 @@ defmodule Predicator.Mixfile do
       docs: [extras: ["README.md"]],
       links: %{"GitHub" => "https://github.com/predicator/predicator_elixir"}
     ]
+  end
+
+  defp aliases() do
+    [compile: "compile --warnings-as-errors"]
   end
 
   def application() do

--- a/test/predicator/errors/insctruction_error_test.exs
+++ b/test/predicator/errors/insctruction_error_test.exs
@@ -1,3 +1,4 @@
 defmodule Predicator.InstructionErrorTest do
-  use ExUnit.Case; doctest Predicator.InstructionError
+  use ExUnit.Case
+  doctest Predicator.InstructionError
 end

--- a/test/predicator/errors/value_error_test.exs
+++ b/test/predicator/errors/value_error_test.exs
@@ -1,3 +1,4 @@
 defmodule Predicator.ValueErrorTest do
-  use ExUnit.Case; doctest Predicator.ValueError
+  use ExUnit.Case
+  doctest Predicator.ValueError
 end

--- a/test/predicator/evaluator_operations/between_test.exs
+++ b/test/predicator/evaluator_operations/between_test.exs
@@ -5,6 +5,7 @@ defmodule Predicator.EvaluatorOperation.BetweenTest do
   defmodule TstStruct, do: defstruct [created_at: "2012-12-12"]
 
   describe "[\"BETWEEN\"] operation" do
+    @tag :current
     test "inclusive evaluation of integer BETWEEN integers" do
       inst  = [["lit", 3], ["lit", 1], ["lit", 5], ["compare", "BETWEEN"]]
       inst2 = [["lit", 1], ["lit", 1], ["lit", 5], ["compare", "BETWEEN"]]

--- a/test/predicator/evaluator_operations/blank_test.exs
+++ b/test/predicator/evaluator_operations/blank_test.exs
@@ -1,5 +1,3 @@
-
-
 defmodule Predicator.EvaluatorOperation.BlankTest do
   use ExUnit.Case
   import Predicator.Evaluator

--- a/test/predicator/evaluator_operations/not_in_test.exs
+++ b/test/predicator/evaluator_operations/not_in_test.exs
@@ -1,4 +1,3 @@
-
 defmodule Predicator.EvaluatorOperation.NotInTest do
   use ExUnit.Case
   import Predicator.Evaluator

--- a/test/predicator/evaluator_operations/present_test.exs
+++ b/test/predicator/evaluator_operations/present_test.exs
@@ -1,4 +1,3 @@
-
 defmodule Predicator.EvaluatorOperation.PresentTest do
   use ExUnit.Case
   import Predicator.Evaluator

--- a/test/predicator/evaluator_operations/to_bool_test.exs
+++ b/test/predicator/evaluator_operations/to_bool_test.exs
@@ -1,4 +1,3 @@
-
 defmodule Predicator.EvaluatorOperation.ToBoolTest do
   use ExUnit.Case
   import Predicator.Evaluator

--- a/test/predicator/evaluator_operations/to_date_test.exs
+++ b/test/predicator/evaluator_operations/to_date_test.exs
@@ -1,7 +1,6 @@
 defmodule Predicator.EvaluatorOperation.ToDateTest do
   use ExUnit.Case
   import Predicator.Evaluator
-  import Predicator.Evaluator.Date, only: [_execute: 2, _convert_date: 1]
 
   defmodule TestUser, do: defstruct [created_at: "2012-01-31 18:14:13.0", string_age: "29", age: 29]
 

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -71,10 +71,10 @@ defmodule Predicator.EvaluatorTest do
       inst3 = execute([["lit", true],["to_bool"]], %TestUser{})
       inst4 = execute([["lit", "2010-01-31"],["to_date"]], %TestUser{})
 
-      assert inst1 = {:error, %Predicator.InstructionNotCompleteError{}}
-      assert inst2 = {:error, %Predicator.InstructionNotCompleteError{}}
-      assert inst3 = {:error, %Predicator.InstructionNotCompleteError{}}
-      assert inst4 = {:error, %Predicator.InstructionNotCompleteError{}}
+      assert {:error, %Predicator.InstructionNotCompleteError{}} = inst1
+      assert {:error, %Predicator.InstructionNotCompleteError{}} = inst2
+      assert {:error, %Predicator.InstructionNotCompleteError{}} = inst3
+      assert {:error, %Predicator.InstructionNotCompleteError{}} = inst4
     end
 
     test "InstructionError on invalid predicate op" do

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -2,4 +2,91 @@ defmodule PredicatorTest do
   use ExUnit.Case
   import Predicator
   doctest Predicator
+
+  describe "BETWEEN" do
+    test "not currently supported" do
+      assert {:error, _} = Predicator.compile("age between 5 and 10")
+    end
+  end
+
+  describe "BLANK" do
+    test "not currently supported" do
+      assert {:error, _} = Predicator.compile("name blank")
+    end
+  end
+
+  describe "ENDSWITH" do
+    test "not currently supported" do
+      assert {:error, _} = Predicator.compile("name ends with 'stuff'")
+    end
+  end
+
+  describe "EQ" do
+    test "compiles" do
+      assert {:ok, _} = Predicator.compile("foo = 1")
+    end
+
+    test "returns true if the equality is true" do
+      assert Predicator.matches?("foo = 1", foo: 1) == true
+    end
+
+    test "returns false if the equality is untrue" do
+      assert Predicator.matches?("foo = 1", foo: 2) == false
+    end
+  end
+
+  describe "GT" do
+    test "compiles" do
+      assert {:ok, _} = Predicator.compile("foo > 1")
+    end
+
+    test "returns true if the inequality is true" do
+      assert Predicator.matches?("foo > 1", foo: 2) == true
+    end
+
+    test "returns false if the inequality is untrue" do
+      assert Predicator.matches?("foo > 1", foo: 1) == false
+    end
+  end
+
+  describe "IN" do
+    test "not currently supported" do
+      assert {:error, _} = Predicator.compile("foo in [1, 2, 3]")
+    end
+  end
+
+  describe "JUMP" do
+  end
+
+  describe "LT" do
+    test "compiles" do
+      assert {:ok, _} = Predicator.compile("foo < 1")
+    end
+
+    test "returns true if the inequality is true" do
+      assert Predicator.matches?("foo < 1", foo: 0) == true
+    end
+
+    test "returns false if the inequality is untrue" do
+      assert Predicator.matches?("foo < 1", foo: 1) == false
+    end
+  end
+
+  describe "NOTIN" do
+    test "not currently supported" do
+      assert {:error, _} = Predicator.compile("foo not in [1, 2, 3]")
+    end
+  end
+
+  describe "PRESENT" do
+    test "not currently supported" do
+      assert {:error, _} = Predicator.compile("name present")
+    end
+  end
+
+  describe "STARTSWITH" do
+    test "not currently supported" do
+      assert {:error, _} = Predicator.compile("name starts with 'stuff'")
+    end
+  end
 end


### PR DESCRIPTION
Defines which predicates are currently supported and unsupported.

Refactors the evaluation logic:
1. Creates a machine struct with functions for operating on it
1. Separates operations on the machine from iteration logic
1. Creates a simple api on `Predicator` to allow passing in a string and context and get `true|false` back.