### PR TITLE
parse double quoted strings

### DIFF
--- a/src/predicate_lexer.xrl
+++ b/src/predicate_lexer.xrl
@@ -14,7 +14,7 @@ ATOM         = :[a-z_]+
 IDENTIFIER   = [a-z][A-Za-z0-9_]*
 INTEGER      = [0-9]+
 SYMBOLS      = [{}\[\],]
-STRING       = '((\?:\\.|[^\\''])*)'
+STRING       = ("((\?:\\.|[^\\""])*)"|'((\?:\\.|[^\\''])*)')
 BOOLEAN      = (true|false)
 
 
@@ -42,5 +42,7 @@ Rules.
 
 
 Erlang code.
+sanitized_string("'" ++ _Rest = Str) ->
+  string:trim(list_to_binary(Str), both, "'");
 sanitized_string(Str) ->
-  string:trim(list_to_binary(Str), both, "'").
+  string:trim(list_to_binary(Str), both, "\"").

--- a/test/predicate_lexer_test.exs
+++ b/test/predicate_lexer_test.exs
@@ -1,0 +1,17 @@
+defmodule Predicator.PredicateLexerTest do
+  use ExUnit.Case
+
+  @lexer :predicate_lexer
+
+  describe "string" do
+    test "lexes string wrapped in single quotes" do
+      example = "'foo'" |> to_charlist()
+      assert {:ok, [{:string, "foo", 1}], 1} == @lexer.string(example)
+    end
+
+    test "lexes string wrapped in double quotes" do
+      example = "\"foo\"" |> to_charlist()
+      assert {:ok, [{:string, "foo", 1}], 1} == @lexer.string(example)
+    end
+  end
+end


### PR DESCRIPTION
parses double quoted strings to make it backwards compatible with ruby predicator 😎 